### PR TITLE
Zoom fields on Participants should be read-only, like the Zoom fields on Events

### DIFF
--- a/xml/zoomzoom_install.xml
+++ b/xml/zoomzoom_install.xml
@@ -38,8 +38,8 @@
             <column_name>zoom_id</column_name>
             <serialize>0</serialize>
             <in_selector>0</in_selector>
-            <custom_group_name>zoom</custom_group_name>
             <is_view>1</is_view>
+            <custom_group_name>zoom</custom_group_name>
         </CustomField>
         <CustomField>
             <name>password</name>
@@ -47,7 +47,7 @@
             <data_type>String</data_type>
             <html_type>Text</html_type>
             <is_required>0</is_required>
-            <is_searchable>1</is_searchable>
+            <is_searchable>0</is_searchable>
             <is_search_range>0</is_search_range>
             <weight>2</weight>
             <is_active>1</is_active>
@@ -57,8 +57,8 @@
             <column_name>password</column_name>
             <serialize>0</serialize>
             <in_selector>0</in_selector>
-            <custom_group_name>zoom</custom_group_name>
             <is_view>1</is_view>
+            <custom_group_name>zoom</custom_group_name>
         </CustomField>
         <CustomField>
             <name>start_url</name>
@@ -66,7 +66,7 @@
             <data_type>Memo</data_type>
             <html_type>TextArea</html_type>
             <is_required>0</is_required>
-            <is_searchable>1</is_searchable>
+            <is_searchable>0</is_searchable>
             <is_search_range>0</is_search_range>
             <weight>3</weight>
             <is_active>1</is_active>
@@ -75,8 +75,8 @@
             <column_name>start_url</column_name>
             <serialize>0</serialize>
             <in_selector>0</in_selector>
-            <custom_group_name>zoom</custom_group_name>
             <is_view>1</is_view>
+            <custom_group_name>zoom</custom_group_name>
         </CustomField>
         <CustomField>
             <name>join_url</name>
@@ -84,7 +84,7 @@
             <data_type>Memo</data_type>
             <html_type>TextArea</html_type>
             <is_required>0</is_required>
-            <is_searchable>1</is_searchable>
+            <is_searchable>0</is_searchable>
             <is_search_range>0</is_search_range>
             <weight>4</weight>
             <is_active>1</is_active>
@@ -93,8 +93,8 @@
             <column_name>join_url</column_name>
             <serialize>0</serialize>
             <in_selector>0</in_selector>
-            <custom_group_name>zoom</custom_group_name>
             <is_view>1</is_view>
+            <custom_group_name>zoom</custom_group_name>
         </CustomField>
         <CustomField>
             <name>registration_url</name>
@@ -102,7 +102,7 @@
             <data_type>Memo</data_type>
             <html_type>TextArea</html_type>
             <is_required>0</is_required>
-            <is_searchable>1</is_searchable>
+            <is_searchable>0</is_searchable>
             <is_search_range>0</is_search_range>
             <weight>5</weight>
             <is_active>1</is_active>
@@ -111,8 +111,8 @@
             <column_name>registration_url</column_name>
             <serialize>0</serialize>
             <in_selector>0</in_selector>
-            <custom_group_name>zoom</custom_group_name>
             <is_view>1</is_view>
+            <custom_group_name>zoom</custom_group_name>
         </CustomField>
         <CustomField>
             <name>global_dial_in_numbers</name>
@@ -120,7 +120,7 @@
             <data_type>Memo</data_type>
             <html_type>RichTextEditor</html_type>
             <is_required>0</is_required>
-            <is_searchable>1</is_searchable>
+            <is_searchable>0</is_searchable>
             <is_search_range>0</is_search_range>
             <weight>6</weight>
             <is_active>1</is_active>
@@ -129,8 +129,8 @@
             <column_name>global_dial_in_numbers</column_name>
             <serialize>0</serialize>
             <in_selector>0</in_selector>
-            <custom_group_name>zoom</custom_group_name>
             <is_view>1</is_view>
+            <custom_group_name>zoom</custom_group_name>
         </CustomField>
     </CustomFields>
     <OptionValues>

--- a/xml/zoomzoom_registrant_install.xml
+++ b/xml/zoomzoom_registrant_install.xml
@@ -27,7 +27,7 @@
       <data_type>String</data_type>
       <html_type>Text</html_type>
       <is_required>0</is_required>
-      <is_searchable>1</is_searchable>
+      <is_searchable>0</is_searchable>
       <is_search_range>0</is_search_range>
       <weight>1</weight>
       <is_active>1</is_active>
@@ -37,6 +37,7 @@
       <column_name>zoom_id</column_name>
       <serialize>0</serialize>
       <in_selector>0</in_selector>
+      <is_view>1</is_view>
       <custom_group_name>zoom_registrant</custom_group_name>
     </CustomField>
     <CustomField>
@@ -45,7 +46,7 @@
       <data_type>String</data_type>
       <html_type>Text</html_type>
       <is_required>0</is_required>
-      <is_searchable>1</is_searchable>
+      <is_searchable>0</is_searchable>
       <is_search_range>0</is_search_range>
       <weight>1</weight>
       <is_active>1</is_active>
@@ -55,6 +56,7 @@
       <column_name>registrant_id</column_name>
       <serialize>0</serialize>
       <in_selector>0</in_selector>
+      <is_view>1</is_view>
       <custom_group_name>zoom_registrant</custom_group_name>
     </CustomField>
     <CustomField>
@@ -63,7 +65,7 @@
       <data_type>Memo</data_type>
       <html_type>TextArea</html_type>
       <is_required>0</is_required>
-      <is_searchable>1</is_searchable>
+      <is_searchable>0</is_searchable>
       <is_search_range>0</is_search_range>
       <weight>2</weight>
       <is_active>1</is_active>
@@ -72,6 +74,7 @@
       <column_name>join_url</column_name>
       <serialize>0</serialize>
       <in_selector>0</in_selector>
+      <is_view>1</is_view>
       <custom_group_name>zoom_registrant</custom_group_name>
     </CustomField>
   </CustomFields>


### PR DESCRIPTION
Zoom fields on Participants should be read-only, like the Zoom fields on Events. The only reason these were editable was to allow the Zoom registration to be disconnected (ie. blank to remove and re-create) - this is less likely in practise.

Making them the same (read-only) would make more sense.

For Zoom Event fields, remove is_searchable and move position of is_view in XM

Agileware Ref: CIVIZOOM-73